### PR TITLE
Handle TrustKit and Texture to could be merged

### DIFF
--- a/lib/cocoapods-pod-merge/Main.rb
+++ b/lib/cocoapods-pod-merge/Main.rb
@@ -331,7 +331,7 @@ module CocoapodsPodMerge
       # Generate Module Map
       unless mixed_language_group
         Pod::UI.puts "\tGenerating module map".magenta
-        generate_module_map(merged_framework_name, public_headers_by_pod)
+        generate_module_map(merged_framework_name, public_headers_by_pod, private_header_files)
       end
 
       # Verify there's a common Swift language version across the group
@@ -491,13 +491,14 @@ module CocoapodsPodMerge
       file&.close
     end
 
-    def generate_module_map(merged_framework_name, public_headers)
+    def generate_module_map(merged_framework_name, public_headers, private_headers)
+      private_filenames = private_headers.map { |path| File.basename(path) } 
       module_map = File.new("#{InstallationDirectory}/#{merged_framework_name}/Sources/module.modulemap", 'w')
       module_map.puts("framework module #{merged_framework_name} {")
       public_headers.each do |pod, headers|
         module_map.puts("\n\texplicit module #{pod.delete('+').delete('_')} {")
-
         headers.each do |header|
+          next if private_filenames.include?(header)
           module_map.puts("\t\theader \"#{header}\"")
         end
         module_map.puts("\t}")


### PR DESCRIPTION
**DON'T MERGE YET.**

still have an error with Texture
https://github.com/bl-core-vitals/Texture/blob/pod_mergeable/Texture.podspec
> #import <vector>
<img width="527" alt="Screen Shot 2019-12-19 at 18 02 12" src="https://user-images.githubusercontent.com/3015018/71168613-b9b91580-2289-11ea-8972-0cc36c34f6d7.png">

- [x] Podspec has _module_name_ like Texture (AsyncDisplayKit)
- [x] Podspec has _public_header_files_ will take to modulemap group merge
- [x] Pod with the private files will not set as Public target by private_header_files